### PR TITLE
web_debranding: Fix for handling uncaught Exceptions

### DIFF
--- a/web_debranding/static/src/js/dialog.js
+++ b/web_debranding/static/src/js/dialog.js
@@ -28,7 +28,11 @@ function web_debranding_dialog(instance) {
                     options['title'] = title;
                 }
                 if (content){
-                    var content_html = content.html().replace(/Odoo/ig, parent.debranding_new_name);
+                    if (typeof content == "string") {
+                        var content_html = content.replace(/Odoo/ig, parent.debranding_new_name);
+                    } else {
+                        var content_html = content.html().replace(/Odoo/ig, parent.debranding_new_name);
+                    }
                     content.html(content_html);
                 }
             }


### PR DESCRIPTION
Uncaught errors from the server seem to be passed to instance.web.Dialog.include::init here as string rather than jquery objects
and so introducing a conditional to check the variable type.

4ca060c2417f795e7925e478d1a30da41753d59e doesn't properly fix this
