### PR TITLE
Convert images during module installation

### DIFF
--- a/product_image_filestore/README.rst
+++ b/product_image_filestore/README.rst
@@ -32,11 +32,25 @@ Regular Installation:
     may be safely deleted as they would never have decoded to a valid image
     anyway.
 
+Post-Install:
+-------------
+
     After the process is complete, the original fields remain in the database
     but are renamed to the same name with the "_bkp" suffix. For successfully
     converted records, the contents are set to null; for failed conversions,
     the original data remains in the field. This data is the same data that's
     also written to the files in /tmp.
+
+    The files in /tmp are the most convenient way to retrieve all information
+    pertaining failed conversions. Since this folder is emptied upon reboot,
+    a secondary backup is left in the database in the form of the image_bkp and
+    image_variant_bkp columns in product_template and product_product. After a
+    successful install, or after concluding the investigation into the failure,
+    these columns can safely be dropped via following commands:::
+
+        ALTER TABLE product_template DROP COLUMN image_bkp;
+        ALTER TABLE product_product  DROP COLUMN image_variant_bkp;
+
 
 Export/Import:
 --------------

--- a/product_image_filestore/README.rst
+++ b/product_image_filestore/README.rst
@@ -51,7 +51,10 @@ Export/Import:
     field limit (131072)". A solution for this error can be found at the
     link below.
 
-    After uninstalling this module you also have to update the "product"
+Deinstalling:
+-------------
+
+    After deinstalling this module you also have to update the "product"
     module. This causes an update of all dependent modules. This operation
     is destructive in the sense that it will remove all product images.
     If you wish to retain them, see Export/Import above.

--- a/product_image_filestore/README.rst
+++ b/product_image_filestore/README.rst
@@ -1,20 +1,73 @@
-This module uses ir.attachment table to handle product images. It
-allows store product images on a disk instead of a database.
+Description
+===========
+
+This module stores the product images in the filestore instead of the database.
+It achieves this by storing them as attachments, rather than binary fields on
+the Product / Product Variant models.
 
 WARNING
 =======
 
-    Installation or deleting this module will cause lost of your
-    current product images. Before doing it you have to export images
-    from all product variants and then import it back after
-    installation or deleting the module.
+Regular Installation:
+---------------------
 
-    During importing images, you can get error "field larger than
-    field limit (131072)". At the link below you can find a solution.
+    Before installing this module, perform a backup of your database,
+    and preferably your filestore. Alternatively, instead of backing up
+    your filestore, create a listing of the files it contains. That way
+    you can remove the newly created files in case you wish to perform
+    a rollback.
 
-    After unintalling this module you also have to update "product"
-    module. This cause updating of all dependent modules.
+    During installation, the images are migrated from the DB to the
+    filestore, through direct database intervention. This is an invasive
+    procecure and not entirely without risk. Therefore, having a rollback
+    procedure in place as described above is highly recommended.
 
-Tested on Odoo 8.0 935141582f5245f7cf5512285d3d91dfe58cb570
+    If errors are encountered during installation, an error is logged and
+    the contents of the image field in the offending product or variant is
+    saved to /tmp/product_template_image_${id}.b64 or
+    /tmp/product_product_${id}.b64 for inspection. These files contain the raw
+    field data, which under normal circumstances should contain the base64
+    encoded contents of the image file, but in some cases may contain
+    invalid data such as the string "[False]". If this is the case, those files
+    may be safely deleted as they would never have decoded to a valid image
+    anyway.
+
+    After the process is complete, the original fields remain in the database
+    but are renamed to the same name with the "_bkp" suffix. For successfully
+    converted records, the contents are set to null; for failed conversions,
+    the original data remains in the field. This data is the same data that's
+    also written to the files in /tmp.
+
+Export/Import:
+--------------
+
+    The previous way of retaining your product images is still supported:
+    prior to installing this module, export all images from all products
+    and product variants, and after installing (or removing) the module,
+    re-import them. This should not be necessary as the module now takes
+    care of this during installation, but it's still supported.
+
+    While importing images, you can encounter the error "field larger than
+    field limit (131072)". A solution for this error can be found at the
+    link below.
+
+    After uninstalling this module you also have to update the "product"
+    module. This causes an update of all dependent modules. This operation
+    is destructive in the sense that it will remove all product images.
+    If you wish to retain them, see Export/Import above.
+
+Tested on Odoo 8.0 935141582f5245f7cf5512285d3d91dfe58cb570 and
+d24ff706a9194fe33c9f98aca0c0424486b661cf
 
 Further information and discussion: http://yelizariev.github.io/odoo/module/2015/03/06/product-image-filestore.html
+
+Credits
+=======
+
+Author:
+-------
+    * Ivan Yelizariev, IT-Projects LLC, https://github.com/yelizariev
+
+Contributors:
+-------------
+    * Juan Rial, Dynapps, https://github.com/jrial


### PR DESCRIPTION
Ivan,

Here's a small improvement to product_image_filestore. It now automatically converts the images from the binary fields to the filestore by first setting the data aside in a renamed column before the new models are loaded, and after they are loaded it will use the data from this set-aside column to rewrite the records. That way no manual import/export is required.

After this is done, it will rename the column one last time, so that subsequent module upgrades don't try to redo the process again.

Remark: this process can take a while, and means installing this module for the first time will take considerably longer, depending on the number of product images in the system. Upgrading the module after that will not take noticeably longer as the module detects when it has performed these transformations, and will skip them if they have already been applied.

Feel free to give feedback if there's anything you feel should be done differently.
