### PR TITLE
[ADD] Fix partner notify_email before uninstall

### DIFF
--- a/im_notif/__init__.py
+++ b/im_notif/__init__.py
@@ -1,1 +1,8 @@
 import im_notif_models
+
+
+def pre_uninstall(cr, registry):
+    query = ("UPDATE res_partner "
+             "SET notify_email = 'always' "
+             "WHERE notify_email LIKE 'im%';")
+    cr.execute(query)

--- a/im_notif/__openerp__.py
+++ b/im_notif/__openerp__.py
@@ -14,4 +14,5 @@
         'im_notif_views.xml',
         ],
     'installable': True
+    'uninstall_hook': 'pre_uninstall',
 }


### PR DESCRIPTION
In the [blog post](https://yelizariev.github.io/odoo/module/2015/02/18/im-notifications.html) about this module, it says:

> Before uninstalling you have to find all partners with IM values in field "Receive Inbox Notifications by Email" and change it to standard "Never" or "Only emails". ("Only emails" is renamed by module from "All Message")

This patch does that work for the user. 
