### PR TITLE
[FIX] reminder_base, invalid syntax

### DIFF
--- a/reminder_base/reminder_base_models.py
+++ b/reminder_base/reminder_base_models.py
@@ -29,7 +29,9 @@ class reminder(models.AbstractModel):
             'start_date': fields.Date.today(),
             'stop_date': fields.Date.today(),
         }
-        event = self.env['calendar.event'].with_context({no_mail_to_attendees=True}).create(vals)
+        event = self.env['calendar.event'].with_context({
+            'no_mail_to_attendees': True
+        }).create(vals)
         return event
 
     @api.model


### PR DESCRIPTION
After update this repo, the ERP raises a syntax error. It's on a recently changed line for #120.
