### PR TITLE
[ADD] thecage_data: restriction for front desk (See all Leads)

### DIFF
--- a/booking_calendar/models.py
+++ b/booking_calendar/models.py
@@ -203,13 +203,6 @@ class sale_order_line(models.Model):
             'color': b.resource_id.color
         } for b in bookings]
 
-    @api.multi
-    def unlink(self):
-        cancelled = self.filtered(lambda line: line.state == 'cancel')
-        self.write({'active': False})
-        (self - cancelled).button_cancel()
-        super(sale_order_line, cancelled).unlink()
-
     @api.onchange('booking_start', 'booking_end')
     def _on_change_booking_time(self):
         domain = {'product_id': []}

--- a/thecage_data/data.xml
+++ b/thecage_data/data.xml
@@ -46,6 +46,16 @@
         <record id="base.user_root" model="res.users">
             <field name="company_ids" eval="[(4, ref('res_company_bt')),(4, ref('res_company_kl')),]"/>
         </record>
+        <!--                      Groups                        -->
+        <record id="group_frontdesk" model="res.groups">
+          <field name="name">Front Desk</field>
+          <field name="implied_ids" eval="[(4, ref('base.group_sale_salesman_all_leads'))]"/>
+        </record>
+        <record id="group_bookingstaff" model="res.groups">
+          <field name="name">Booking Staff</field>
+          <field name="implied_ids" eval="[(4, ref('base.group_sale_manager'))]"/>
+        </record>
+
 
         <!--                   Venues                   -->
         <record id="venue_kallang" model="pitch_booking.venue">
@@ -410,6 +420,13 @@
           <field name="perm_unlink" eval="1" />
           <field name="domain_force">[('venue_id.company_id','=',user.company_id.id)]</field>
         </record>
+        <record id="sale_order_line_unlink" model="ir.rule">
+          <field name="name">restrict deletion for See All Leads users</field>
+          <field name="model_id" ref="sale.model_sale_order_line"/>
+          <field name="perm_unlink" eval="1" />
+          <field name="domain_force">[('product_id.type','!=','service')]</field>
+        </record>
+
 
     </data>
 </openerp>

--- a/thecage_data/views/view.xml
+++ b/thecage_data/views/view.xml
@@ -230,7 +230,7 @@
           </xpath>
         </field>
       </record>
-      <record id="thecage_view_booking_order_line_form_allow_edit_state_to_all_leads" model="ir.ui.view">
+      <record id="thecage_view_booking_order_line_form_edit_state_to_all_leads" model="ir.ui.view">
         <field name="name">thecage.booking.order.line</field>
         <field name="model">sale.order.line</field>
         <field name="inherit_id" ref="thecage_view_booking_order_line_form"/>

--- a/thecage_data/views/view.xml
+++ b/thecage_data/views/view.xml
@@ -108,10 +108,12 @@
                 <header class="oe_edit_only" attrs="{'invisible': [('state', 'not in', ['draft', 'sent'])]}">
                     <button type="action"
                             name="%(thecage_generate_booking_action)d"
-                            string="Generate Booking Lines"/>
+                            string="Generate Booking Lines"
+                            groups = "base.group_sale_manager" />
                     <button type="object"
                             name="remove_generated_lines"
-                            string="Remove generated Lines"/>
+                            string="Remove generated Lines"
+                            groups = "base.group_sale_manager" />
                 </header>
             </xpath>
         </field>
@@ -147,9 +149,37 @@
         <field name="name">sale.order.line.tree</field>
         <field name="model">sale.order.line</field>
         <field name="inherit_id" ref="thecage_view_booking_order_line_tree"/>
-        <field name="groups_id" eval="[(4, ref('base.group_erp_manager'), 0)]"/>
+        <field name="groups_id" eval="[(4, ref('base.group_sale_manager'), 0)]"/>
         <field name="arch" type="xml">
           <xpath expr="//field[@name='booking_state']" position="attributes">
+            <attribute name="readonly">0</attribute>
+          </xpath>
+        </field>
+      </record>
+
+      <record id="pitch_booking_view_booking_order_line_form" model="ir.ui.view">
+        <field name="name">pitch.booking.order.line</field>
+        <field name="model">sale.order.line</field>
+        <field name="inherit_id" ref="pitch_booking.view_booking_order_line_form"/>
+        <field name="arch" type="xml">
+          <xpath expr="//field[@name='venue_id']" position="attributes">
+            <attribute name="readonly">1</attribute>
+          </xpath>
+          <xpath expr="//field[@name='pitch_id']" position="attributes">
+            <attribute name="readonly">1</attribute>
+          </xpath>
+        </field>
+      </record>
+      <record id="pitch_booking_view_booking_order_line_form_state" model="ir.ui.view">
+        <field name="name">pitch.booking.order.line</field>
+        <field name="model">sale.order.line</field>
+        <field name="inherit_id" ref="pitch_booking_view_booking_order_line_form"/>
+        <field name="groups_id" eval="[(4, ref('base.group_sale_manager'), 0)]"/>
+        <field name="arch" type="xml">
+          <xpath expr="//field[@name='venue_id']" position="attributes">
+            <attribute name="readonly">0</attribute>
+          </xpath>
+          <xpath expr="//field[@name='pitch_id']" position="attributes">
             <attribute name="readonly">0</attribute>
           </xpath>
         </field>
@@ -163,20 +193,55 @@
           <xpath expr="//field[@name='price_unit']" position="after">
             <field name="booking_state" readonly="1" />
           </xpath>
+          <xpath expr="//field[@name='partner_id']" position="attributes">
+            <attribute name="readonly">1</attribute>
+          </xpath>
+          <xpath expr="//field[@name='project_id']" position="attributes">
+            <attribute name="readonly">1</attribute>
+          </xpath>
+          <xpath expr="//field[@name='booking_start']" position="attributes">
+            <attribute name="readonly">1</attribute>
+          </xpath>
+          <xpath expr="//field[@name='booking_end']" position="attributes">
+            <attribute name="readonly">1</attribute>
+          </xpath>
         </field>
       </record>
-      <record id="thecage_view_booking_order_line_form_state" model="ir.ui.view">
+      <record id="thecage_view_booking_order_line_form_allow_edit_all_to_manager" model="ir.ui.view">
         <field name="name">thecage.booking.order.line</field>
         <field name="model">sale.order.line</field>
         <field name="inherit_id" ref="thecage_view_booking_order_line_form"/>
-        <field name="groups_id" eval="[(4, ref('base.group_erp_manager'), 0)]"/>
+        <field name="groups_id" eval="[(4, ref('base.group_sale_manager'), 0)]"/>
+        <field name="arch" type="xml">
+          <xpath expr="//field[@name='booking_state']" position="attributes">
+            <attribute name="readonly">0</attribute>
+          </xpath>
+          <xpath expr="//field[@name='partner_id']" position="attributes">
+            <attribute name="readonly">0</attribute>
+          </xpath>
+          <xpath expr="//field[@name='project_id']" position="attributes">
+            <attribute name="readonly">0</attribute>
+          </xpath>
+          <xpath expr="//field[@name='booking_start']" position="attributes">
+            <attribute name="readonly">0</attribute>
+          </xpath>
+          <xpath expr="//field[@name='booking_end']" position="attributes">
+            <attribute name="readonly">0</attribute>
+          </xpath>
+        </field>
+      </record>
+      <record id="thecage_view_booking_order_line_form_allow_edit_state_to_all_leads" model="ir.ui.view">
+        <field name="name">thecage.booking.order.line</field>
+        <field name="model">sale.order.line</field>
+        <field name="inherit_id" ref="thecage_view_booking_order_line_form"/>
+        <field name="groups_id" eval="[(4, ref('base.group_sale_salesman_all_leads'), 0)]"/>
         <field name="arch" type="xml">
           <xpath expr="//field[@name='booking_state']" position="attributes">
             <attribute name="readonly">0</attribute>
           </xpath>
         </field>
       </record>
-
+      
       <record id="thecage_view_order_form" model="ir.ui.view">
         <field name="name">sale.order.form</field>
         <field name="model">sale.order</field>
@@ -191,7 +256,7 @@
         <field name="name">sale.order.form</field>
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="thecage_view_order_form"/>
-        <field name="groups_id" eval="[(4, ref('base.group_erp_manager'), 0)]"/>
+        <field name="groups_id" eval="[(4, ref('base.group_sale_manager'), 0)]"/>
         <field name="arch" type="xml">
           <xpath expr="//field[@name='booking_state']" position="attributes">
             <attribute name="readonly">0</attribute>


### PR DESCRIPTION
front desk users are members of 'See all Leads' group. They should have access to edit only one booking field - 'booking_state'. They should not cancell booking.
