### PR TITLE
[FIX] thecage_data: remove product.product write. This was done before

### DIFF
--- a/thecage_data/models.py
+++ b/thecage_data/models.py
@@ -290,17 +290,4 @@ class AccountInvoice(models.Model):
 
         return super(AccountInvoice, self).invoice_validate()
 
-class ProductProduct(models.Model):
-    _inherit = "product.product"
-
-    @api.one
-    def write(self, vals):
-        # for ordinary products, not booking
-        # we don't need to write such field as venue_id to product
-        # Why there is such need for booking I don't know
-        if vals['venue_id'] == False:
-            return
-        return super(ProductProduct, self).write(vals)
-
-
 


### PR DESCRIPTION
because users in group 'See All Leads' (Frontdesk) don't have rights to modify
products. They also don't have access to calendar.calendar model and
can't create bookings. But they should be able to create sale orders
with ordinary products that is not related with calendar. There was an
issue on creating sale orders by Frontdesk with ordinary products such
as in the moment of saving sale order there was an access error. Somehow
on saving sale order system is trying to write in product.product model.
The solution is wrong. Need to do another solution.
