### PR TITLE
[FIX] don't update FieldUpgradeBoolean on enterprise

### DIFF
--- a/web_debranding/__openerp__.py
+++ b/web_debranding/__openerp__.py
@@ -1,6 +1,6 @@
 {
     'name': "Backend debranding",
-    'version': '1.0.6',
+    'version': '1.0.7',
     'author': 'IT-Projects LLC, Ivan Yelizariev',
     'license': 'LGPL-3',
     'category': 'Debranding',

--- a/web_debranding/doc/changelog.rst
+++ b/web_debranding/doc/changelog.rst
@@ -3,6 +3,11 @@
 Changelog
 =========
 
+`1.0.7`
+-------
+
+- FIX: bug with fields on User form in Odoo Enterprise
+
 `1.0.6`
 -------
 

--- a/web_debranding/static/src/js/field_upgrade.js
+++ b/web_debranding/static/src/js/field_upgrade.js
@@ -30,6 +30,10 @@ odoo.define('web_debranding.field_upgrade', function (require) {
 
     //skip this for a while as we don't have example to test it
     //UpgradeRadio.include(include);
+    if (UpgradeBoolean.prototype.template != 'FieldUpgradeBoolean'){
+        // we are on enterprise. No need to update
+        return;
+    }
 
     UpgradeBoolean.include(include);
 });


### PR DESCRIPTION
Enteprise use the same class for FieldUpgradeBoolean asn for
FieldBoolean. It leads to hidding usual fields on Enterprise
database (e.g. in User form)
