### PR TITLE
[FIX] don't create partner explicitly, because it could lead

### DIFF
--- a/auth_signup_confirmation/controllers/auth_signup_confirmation.py
+++ b/auth_signup_confirmation/controllers/auth_signup_confirmation.py
@@ -69,22 +69,19 @@ class AuthConfirm(AuthSignupHome):
             new_partner = new_user.partner_id
             new_partner.email = kw['login']
         else:
-            new_partner = request.env['res.partner'].sudo().with_context(signup_force_type_in_url='signup/confirm',
-                                                                         signup_valid=True).create(
-                {
-                    'name': kw['name'],
-                    'email': kw['login'],
-                }
-            )
             res_users = request.env['res.users']
-            values = {'partner_id': new_partner.id,
-                      'login': kw['login'],
+            values = {'login': kw['login'],
+                      'email': kw.get('email') or kw['login'],
                       'password': kw['password'],
                       'name': kw['name'],
                       'alias_name': kw['name']}
-            new_user_id = res_users.sudo()._signup_create_user(values)
+            new_user_id = res_users.sudo().with_context(
+                signup_force_type_in_url='signup/confirm',
+                signup_valid=True
+            )._signup_create_user(values)
             new_user = request.env['res.users'].sudo().search([('id', '=', new_user_id)])
             new_user.active = False
+            new_partner = new_user.partner_id
         redirect_url = werkzeug.url_encode({'redirect': kw['redirect']})
         signup_url = new_partner.with_context(signup_force_type_in_url='signup/confirm',
                                               signup_valid=True)._get_signup_url(SUPERUSER_ID, [new_partner.id])[new_partner.id]

--- a/auth_signup_confirmation/data/config.xml
+++ b/auth_signup_confirmation/data/config.xml
@@ -2,7 +2,7 @@
 <openerp>
 <data noupdate="1">
 
-    <record id="auth_signup_confirmation.url_singup_thankyou" model="ir.config_parameter">
+    <record id="url_singup_thankyou" model="ir.config_parameter">
         <field name="key">auth_signup_confirmation.url_singup_thankyou</field>
         <field name="value">/web/signup/thankyou/</field>
     </record>

--- a/autostaging_base/models.py
+++ b/autostaging_base/models.py
@@ -66,13 +66,8 @@ class AutostagingCard(models.AbstractModel):
 
     @api.multi
     def _get_autostaging_date(self):
-        for r in self:
-            r._get_autostaging_date_one()
-        return True
-
-    @api.multi
-    def _get_autostaging_date_one(self):
         self.ensure_one()
+
         delta = datetime.timedelta(days=getattr(self, self._field_stage_id).autostaging_idle_timeout)
         return (datetime.datetime.strptime(
             self.write_date, DEFAULT_SERVER_DATETIME_FORMAT) + delta).strftime(DEFAULT_SERVER_DATETIME_FORMAT)

--- a/thecage_data/models.py
+++ b/thecage_data/models.py
@@ -97,7 +97,6 @@ class SaleOrderLine(models.Model):
                 r.send_booking_time()
         return result
 
-
     @api.multi
     def send_booking_time(self):
         for r in self:


### PR DESCRIPTION
to error, e.g. when user sends unknown lang setting.

LOG:

2017-02-13 07:23:46,470 11825 INFO 03108-8-0-6561a0-base werkzeug: 127.0.0.1 - - [13/Feb/2017 07:23:46] "GET /web/session/logout HTTP/1.0" 303 -
2017-02-13 07:23:46,554 11825 INFO 03108-8-0-6561a0-base werkzeug: 127.0.0.1 - - [13/Feb/2017 07:23:46] "GET /web HTTP/1.0" 200 -
2017-02-13 07:23:47,139 11825 INFO 03108-8-0-6561a0-base werkzeug: 127.0.0.1 - - [13/Feb/2017 07:23:47] "GET /web/login?redirect=http%3A%2F%2F03108-8-0-6561a0-base.runbot.it-projects.info%2Fweb%3F HTTP/1.0" 200 -
2017-02-13 07:23:48,946 11825 INFO 03108-8-0-6561a0-base werkzeug: 127.0.0.1 - - [13/Feb/2017 07:23:48] "GET /web/signup?redirect=http%3A%2F%2F03108-8-0-6561a0-base.runbot.it-projects.info%2Fweb%3F HTTP/1.0" 200 -
2017-02-13 07:24:00,977 4579 INFO ? openerp.sql_db: ConnectionPool(used=0/count=0/max=64): Closed 1 connections to 'host=172.17.0.3 port=5432 user=odoo password=xxxx dbname=03108-8-0-6561a0-base'
2017-02-13 07:24:01,197 4579 INFO 03108-8-0-6561a0-all openerp.modules.loading: loading 1 modules...
2017-02-13 07:24:01,289 4579 INFO 03108-8-0-6561a0-all openerp.modules.loading: 1 modules loaded in 0.09s, 0 queries
2017-02-13 07:24:01,633 4579 INFO 03108-8-0-6561a0-all openerp.modules.loading: loading 164 modules...
2017-02-13 07:24:01,930 4579 INFO 03108-8-0-6561a0-all openerp.modules.loading: 164 modules loaded in 0.30s, 0 queries
2017-02-13 07:24:02,864 11825 INFO 03108-8-0-6561a0-base werkzeug: 127.0.0.1 - - [13/Feb/2017 07:24:02] "POST /web/signup?redirect=http%3A%2F%2F03108-8-0-6561a0-base.runbot.it-projects.info%2Fweb%3F HTTP/1.0" 500 -
2017-02-13 07:24:03,035 11825 ERROR 03108-8-0-6561a0-base werkzeug: Error on request:
Traceback (most recent call last):
File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 193, in run_wsgi
execute(self.server.app)
File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 181, in execute
application_iter = app(environ, start_response)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/service/wsgi_server.py", line 216, in application
return application_unproxied(environ, start_response)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/service/wsgi_server.py", line 202, in application_unproxied
result = handler(environ, start_response)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/http.py", line 1297, in __call__
return self.dispatch(environ, start_response)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/http.py", line 1271, in __call__
return self.app(environ, start_wrapped)
File "/usr/local/lib/python2.7/dist-packages/werkzeug/wsgi.py", line 599, in __call__
return self.app(environ, start_response)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/http.py", line 1444, in dispatch
result = ir_http._dispatch()
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/addons/crm/ir_http.py", line 13, in _dispatch
response = super(ir_http, self)._dispatch()
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/addons/base/ir/ir_http.py", line 175, in _dispatch
return self._handle_exception(e)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/addons/base/ir/ir_http.py", line 145, in _handle_exception
return request._handle_exception(exception)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/http.py", line 673, in _handle_exception
return super(HttpRequest, self)._handle_exception(exception)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/addons/base/ir/ir_http.py", line 171, in _dispatch
result = request.dispatch()
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/http.py", line 691, in dispatch
r = self._call_function(**self.params)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/http.py", line 317, in _call_function
return checked_call(self.db, *args, **kwargs)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/service/model.py", line 118, in wrapper
return f(dbname, *args, **kwargs)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/http.py", line 314, in checked_call
return self.endpoint(*a, **kw)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/http.py", line 810, in __call__
return self.method(*args, **kw)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/http.py", line 410, in response_wrap
response = f(*args, **kw)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/addons/auth_signup_confirmation/controllers/auth_signup_confirmation.py", line 38, in web_auth_signup
res = self._singup_with_confirmation(*args, **kw)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/addons/auth_signup_confirmation/controllers/auth_signup_confirmation.py", line 76, in _singup_with_confirmation
'email': kw['login'],
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/api.py", line 266, in wrapper
return new_api(self, *args, **kwargs)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/addons/base/res/res_partner.py", line 577, in create
partner = super(res_partner, self).create(vals)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/api.py", line 266, in wrapper
return new_api(self, *args, **kwargs)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/api.py", line 508, in new_api
result = method(self._model, cr, uid, *args, **old_kwargs)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/addons/mail/mail_thread.py", line 381, in create
thread_id = super(mail_thread, self).create(cr, uid, values, context=context)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/api.py", line 268, in wrapper
return old_api(self, *args, **kwargs)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/api.py", line 372, in old_api
result = method(recs, *args, **kwargs)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/models.py", line 4104, in create
record = self.browse(self._create(old_vals))
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/api.py", line 266, in wrapper
return new_api(self, *args, **kwargs)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/api.py", line 508, in new_api
result = method(self._model, cr, uid, *args, **old_kwargs)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/models.py", line 4230, in _create
self._check_selection_field_value(cr, user, field, vals[field], context=context)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/api.py", line 268, in wrapper
return old_api(self, *args, **kwargs)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/api.py", line 372, in old_api
result = method(recs, *args, **kwargs)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/models.py", line 2263, in _check_selection_field_value
field.convert_to_cache(value, self)
File "/mnt/odoo-extra/runbot/static/build/03108-8-0-6561a0/openerp/fields.py", line 1431, in convert_to_cache
raise ValueError("Wrong value for %s: %r" % (self, value))
ValueError: Wrong value for res.partner.lang: 'ru_RU'
127.0.0.1 - - [2017-02-13 07:24:04] "POST /longpolling/poll HTTP/1.0" 200 305 50.124297
2017-02-13 07:24:04,763 4579 INFO 03108-8-0-6561a0-all openerp.modules.loading: Modules loaded.
2017-02-13 07:24:04,871 4579 INFO ? openerp.sql_db: ConnectionPool(used=0/count=0/max=64): Closed 3 connections to 'host=172.17.0.3 port=5432 user=odoo password=xxxx dbname=03108-8-0-6561a0-all'