### PR TITLE
[FIX] mail_move_message got error on change Model field

### DIFF
--- a/web_polymorphic_field/static/src/js/view_form.js
+++ b/web_polymorphic_field/static/src/js/view_form.js
@@ -19,7 +19,7 @@
 odoo.define('web_polymorphic_field.FieldPolymorphic', function (require) {
     var core = require('web.core');
 
-    var FieldSelection = core.form_widget_registry.get('selection')
+    var FieldSelection = core.form_widget_registry.get('selection');
     var FieldPolymorphic = FieldSelection.extend( {
         template: "FieldSelection",
         init: function(field_manager, node) {
@@ -30,23 +30,16 @@ odoo.define('web_polymorphic_field.FieldPolymorphic', function (require) {
             if(this.get_value() != false) {
                 polymorphic_field = this.field_manager.fields[this.polymorphic];
                 polymorphic_field.field.relation = this.get_value();
-                if (reinit) {
-                    polymorphic_field.reinit_value();
-                }
             }
         },
         render_value: function() {
             this._super();
-            this.add_polymorphism(); 
+            this.add_polymorphism();
         },
         store_dom_value: function (e) {
             this._super();
-            var reinit = false;
-            if (e && e.type == 'change') {
-                reinit = true;
-            }
-            this.add_polymorphism(reinit); 
+            this.add_polymorphism();
         }
     });
-    core.form_widget_registry.add('polymorphic', FieldPolymorphic)
+    core.form_widget_registry.add('polymorphic', FieldPolymorphic);
 });


### PR DESCRIPTION
The error message: TypeError: Cannot read property 'constructor' of undefined

There was already a commit, which don't call reinit_value in some cases, but it
seems that we don't need to call at all.

https://github.com/it-projects-llc/misc-addons/commit/9c414d08eb8b4a8f650df6199bb9d2b387d761cc