### PR TITLE
[FIX] UnicodeWarning

### DIFF
--- a/customer_marketing/models/res_partner.py
+++ b/customer_marketing/models/res_partner.py
@@ -5,7 +5,7 @@ from odoo import fields, models
 class Partner(models.Model):
     _inherit = 'res.partner'
 
-    family = fields.Text(string='Family', help="Notes on family members – wife and kids")
+    family = fields.Text(string='Family', help=u"Notes on family members – wife and kids")
     occupation = fields.Text(string='Occupation', help="What do they do for a living")
     recreation = fields.Text(string='Recreation', help="List of things they enjoy doing")
     motivation = fields.Text(string='Motivation', help="What do they like about stuff/mktg")


### PR DESCRIPTION
/mnt/odoo-extra/runbot/static/build/07673-452-b04779/odoo/models.py:362: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  elif not all(cols[field.name][key] == vals[key] for key in vals)