### PR TITLE
[FIX] Fix handling of str vs bytes in WebClientCustom

### DIFF
--- a/web_debranding/controllers/main.py
+++ b/web_debranding/controllers/main.py
@@ -74,7 +74,7 @@ class WebClientCustom(WebClient):
         content, checksum = controllers_main.concat_xml(files)
         if request.context['lang'] == 'en_US':
             # request.env could be not available
-            content = debrand_bytes(request.session.db and request.env or None, content)
+            content = debrand(request.session.db and request.env or None, content)
 
         return controllers_main.make_conditional(
             request.make_response(content, [('Content-Type', 'text/xml')]),


### PR DESCRIPTION
* odoo.addons.web.controllers.main.contac_xml explicitly returns
  a str object, not bytes, hence we should call debrand
  instead of debrand_bytes.

Fixes:

```
[...]
File "/opt/zelo/src/main/odoo/addons/base/ir/ir_http.py", line 208, in _dispatch
  result = request.dispatch()
File "/opt/zelo/src/main/odoo/http.py", line 826, in dispatch
  r = self._call_function(**self.params)
File "/opt/zelo/src/main/odoo/http.py", line 339, in _call_function
  return checked_call(self.db, *args, **kwargs)
File "/opt/zelo/src/main/odoo/service/model.py", line 97, in wrapper
  return f(dbname, *args, **kwargs)
File "/opt/zelo/src/main/odoo/http.py", line 332, in checked_call
  result = self.endpoint(*a, **kw)
File "/opt/zelo/src/main/odoo/http.py", line 933, in __call__
  return self.method(*args, **kw)
File "/opt/zelo/src/main/odoo/http.py", line 512, in response_wrap
  response = f(*args, **kw)
File "/opt/zelo/src/addons/misc-addons/web_debranding/controllers/main.py", line 77, in qweb
  content = debrand_bytes(request.session.db and request.env or None, content)
File "/opt/zelo/src/addons/misc-addons/web_debranding/models/ir_translation.py", line 51, in debrand_bytes
 return bytes(debrand(env, source.decode('utf-8')), 'utf-8')
AttributeError: 'str' object has no attribute 'decode'
```