### PR TITLE
[FIX] thecage_data: this fix addresses the bug in booking reminder:

### DIFF
--- a/thecage_data/models.py
+++ b/thecage_data/models.py
@@ -93,16 +93,14 @@ class SaleOrderLine(models.Model):
     pitch_id = fields.Many2one(track_visibility='onchange')
     product_id = fields.Many2one(track_visibility='onchange')
 
-    @api.onchange('booking_start')
-    def _on_change_booking_start(self):
-        self.booking_reminder = False
-
     @api.multi
     def write(self, vals):
         result = super(SaleOrderLine, self).write(vals)
         for r in self:
             if vals.get('booking_start') or vals.get('booking_end'):
                 r.send_booking_time()
+            if vals.get('booking_start'):
+                self.booking_reminder = False
         return result
 
     @api.multi


### PR DESCRIPTION
1. A booking was done for 23th of Feb 2017.
2. Two days before 23th of Feb 2017, the booking reminder was sent. So
it is working.
3. Customer called after receiving the reminder and changed the booking
to 06th April 2017.
4. Two days before the booking, the booking reminder was NOT sent out.
The solution with onchange didn't work because onchange is a js feature and only
works on forms and only if both 'booking_start' and 'booking_reminder' is on that form