### PR TITLE
[FIX] booking_calendar: also find overlaps when target booking is ful…

### DIFF
--- a/booking_calendar/models.py
+++ b/booking_calendar/models.py
@@ -266,11 +266,19 @@ class SaleOrderLine(models.Model):
         overlaps = 0
 
         if resource_id and booking_start and booking_end:
-            overlaps = self.search_count([('active', '=', True),
-                                          '&', '|', '&', ('booking_start', '>=', booking_start), ('booking_start', '<', booking_end),
+            overlaps = self.search_count(['&',
+                                          '|',
+                                          '&', ('booking_start', '<=', booking_start), ('booking_end', '>=', booking_end),
+                                          '|',
+                                          '&', ('booking_start', '>=', booking_start), ('booking_start', '<', booking_end),
                                           '&', ('booking_end', '>', booking_start), ('booking_end', '<=', booking_end),
+                                          '&',
+                                          ('active', '=', True),
+                                          '&',
                                           ('resource_id', '!=', False),
+                                          '&',
                                           ('id', 'not in', self_ids),
+                                          '&',
                                           ('resource_id', '=', resource_id),
                                           ('state', '!=', 'cancel')])
             _logger.debug('before second search_count')
@@ -302,11 +310,19 @@ class SaleOrderLine(models.Model):
         for line in self:
             if line.overlap:
                 _logger.debug('_check_overlap ******************')
-                overlaps_with = self.search([('active', '=', True),
-                                             '&', '|', '&', ('booking_start', '>', line.booking_start), ('booking_start', '<', line.booking_end),
-                                             '&', ('booking_end', '>', line.booking_start), ('booking_end', '<', line.booking_end),
+                overlaps_with = self.search(['&',
+                                             '|',
+                                             '&', ('booking_start', '<=', line.booking_start), ('booking_end', '>=', line.booking_end),
+                                             '|',
+                                             '&', ('booking_start', '>=', line.booking_start), ('booking_start', '<', line.booking_end),
+                                             '&', ('booking_end', '>', line.booking_start), ('booking_end', '<=', line.booking_end),
+                                             '&',
+                                             ('active', '=', True),
+                                             '&',
                                              ('resource_id', '!=', False),
+                                             '&',
                                              ('id', '!=', line.id),
+                                             '&',
                                              ('resource_id', '=', line.resource_id.id),
                                              ('state', '!=', 'cancel')])
                 overlaps_with += self.search([('active', '=', True),


### PR DESCRIPTION
…ly enclosed with another booking. This scenario:

1. Create and Save a booking Pitch 6 7am to 11am(A).
2. Create and Save an booking Pitch 4 9am to 10am(B).
3. Then move booking (B) to Pitch 6.
4. The booking is allowed. This is wrong because it causes double
booking overlap.