### PR TITLE
:shield: fix random error on CI

### DIFF
--- a/web_website/tests/test_ui.py
+++ b/web_website/tests/test_ui.py
@@ -9,8 +9,7 @@ class TestUI(common.HttpCase):
     post_install = True
 
     def test_ui(self):
-        # FIXME: we cannot use demo user to test, because with no other modules
-        # installed there is no menu but Website which redirects to homepage
+        # FIXME: Use demo user
 
         # needed because tests are run before the module is marked as
         # installed. In js web will only load qweb coming from modules
@@ -21,10 +20,9 @@ class TestUI(common.HttpCase):
             [('name', '=', 'web_website')], limit=1
         ).state = 'installed'
 
-        menu = self.env.ref('website.menu_website_configuration')
         tour = 'web_website.tour'
         self.phantom_js(
-            '/web#menu_id=%i' % menu.id,
+            '/web',
             "odoo.__DEBUG__.services['web_tour.tour']"
             ".run('%s')" % tour,
 


### PR DESCRIPTION
No need to load Website menu. 
It has Dashboard, which loads nvd3 lib, which randomly raise following error:

2018-08-21 17:01:37,914 4541 ERROR openerp_test odoo.addons.web_website.tests.test_ui: ` AssertionError: ('Error loading file http://127.0.0.1:8069/web/static/lib/nvd3/d3.v3.js\n'

This commit also updates note: in 11 version we can use demo user, because there is no Website menu which redirects to root page (website)