### PR TITLE
Module/12.0/product tags

### DIFF
--- a/product_tags/__manifest__.py
+++ b/product_tags/__manifest__.py
@@ -21,7 +21,7 @@
 
 {
     "name": "Product Tags",
-    "version": "10.0.1.0.1",
+    "version": "12.0.1.0.1",
     "author": "Julius Network Solutions",
     "website": "http://julius.fr",
     "category": "Sales Management",
@@ -35,5 +35,5 @@
         'security/ir.model.access.csv',
         'product_view.xml',
     ],
-    'installable': False,
+    'installable': True,
 }

--- a/product_tags/product.py
+++ b/product_tags/product.py
@@ -36,6 +36,7 @@ class ProductTag(models.Model):
     active = fields.Boolean(help='The active field allows you to hide the tag without removing it.', default=True)
     parent_id = fields.Many2one(string='Parent Tag', comodel_name='product.tag', index=True, ondelete='cascade')
     child_ids = fields.One2many(string='Child Tags', comodel_name='product.tag', inverse_name='parent_id')
+    color = fields.Integer('Color Index', default=0)
     parent_path = fields.Char(index=True)
     image = fields.Binary('Image')
 

--- a/product_tags/product_view.xml
+++ b/product_tags/product_view.xml
@@ -95,7 +95,7 @@
             <field name="arch" type="xml">
                 <div name="tags" position="inside">
                     <ul>
-                        <li><field name="tag_ids"/></li>
+                        <li><field name="tag_ids" widget="many2many_tags"/></li>
                     </ul>
                 </div>
             </field>

--- a/product_tags/product_view.xml
+++ b/product_tags/product_view.xml
@@ -17,7 +17,7 @@
                     </group>
                 </form>
             </field>
-        </record>    
+        </record>
 
         <record id="product_tag_tree" model="ir.ui.view">
             <field name="name">product.tag.view.tree</field>
@@ -63,7 +63,7 @@
             groups="base.group_no_one"
             id="menu_product_tag_action_form"
             parent="sale.prod_config_main" sequence="3"/>
-    
+
         <record id="product_template_tag_search_inherit" model="ir.ui.view">
             <field name="name">product.template.tag.view.search</field>
             <field name="model">product.template</field>
@@ -81,7 +81,7 @@
             <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
                 <xpath expr="//h1" position="after">
-                    <field name="tag_ids" widget="many2many_tags" placeholder="Tags..."/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags..."/>
                 </xpath>
             </field>
         </record>
@@ -95,12 +95,12 @@
             <field name="arch" type="xml">
                 <div name="tags" position="inside">
                     <ul>
-                        <li><field name="tag_ids" widget="many2many_tags"/></li>
+                        <li><field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/></li>
                     </ul>
                 </div>
             </field>
         </record>
-        
+
 
     </data>
 </openerp>

--- a/product_tags/security/ir.model.access.csv
+++ b/product_tags/security/ir.model.access.csv
@@ -1,4 +1,4 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_product_tag_all","product_tag_all","model_product_tag",,1,0,0,0
 "access_product_tag_user","product_tag_user","model_product_tag","base.group_user",1,1,1,0
-"access_product_tag_product_manager","product_tag_product_manager","model_product_tag","product.group_mrp_properties",1,1,1,1
+"access_product_tag_product_manager","product_tag_product_manager","model_product_tag","base.group_partner_manager",1,1,1,1


### PR DESCRIPTION
 **[PORT] Fix install issues for product_tags module**

* Make the module installable
* Change `openerp` references to `odoo`
* Change removed group (Manage Properties of Product: `product.group_mrp_properties`) to an existing group (Extra Rights / Contact Creation: `base.group_partner_manager`)
* Convert old `parent_left` and `parent_right` into new-style `parent_store` defind in [this commit](odoo/odoo@e724858)
* Add recursion constraint (from the sale tags in core)
* Update `name_get` and `_name_search` to shadow core as well
* Fix Tag display in kanban view

**[ADD] Color support for product tags, display on product kanban** 

![image](https://user-images.githubusercontent.com/7907616/48668519-dd24f600-eab4-11e8-86ce-ae7e64f67c94.png)

![image](https://user-images.githubusercontent.com/7907616/48668520-e44c0400-eab4-11e8-8d54-facbc6d05f94.png)
