### PR TITLE
[FEAT] ir_attachment_s3: Added support for Minio

### DIFF
--- a/ir_attachment_s3/README.rst
+++ b/ir_attachment_s3/README.rst
@@ -5,6 +5,7 @@
 * The module allows to upload the attachments in Amazon S3 automatically without storing them in Odoo database. It will allow to reduce the load on your server. Attachments will be uploaded on S3 depending on the condition you specified in Odoo settings. So you can choose and manage which type of attachments should be uploaded on S3.
 * It is useful in cases where your database was crashed, because you will be able to easily restore all attachments from external storage at any time.
 * The possibility to use one external storage for any number of databases.
+* Minio can also be used instead of Amazon S3
 
 Credits
 =======
@@ -12,6 +13,7 @@ Credits
 Contributors
 ------------
 * Ildar Nasyrov <iledarn@it-projects.info>
+* Miku Laitinen <miku@avoin.systems>
 
 Sponsors
 --------

--- a/ir_attachment_s3/__manifest__.py
+++ b/ir_attachment_s3/__manifest__.py
@@ -3,7 +3,7 @@
     "summary": """Upload attachments on Amazon S3""",
     "category": "Tools",
     "images": [],
-    "version": "11.0.1.2.0",
+    "version": "11.0.1.3.0",
     "application": False,
 
     "author": "IT-Projects LLC, Ildar Nasyrov",

--- a/ir_attachment_s3/doc/changelog.rst
+++ b/ir_attachment_s3/doc/changelog.rst
@@ -1,3 +1,8 @@
+`1.3.0`
+-------
+
+- **NEW:** Allow using Minio instead of Amazon S3
+
 `1.2.0`
 -------
 

--- a/ir_attachment_s3/doc/index.rst
+++ b/ir_attachment_s3/doc/index.rst
@@ -62,6 +62,8 @@ Configuration
   * ``s3.condition``: only the attachments that meet the condition will be sent to s3 (e.g. ``[('res_model', 'in', ['product.image'])]``) - it is actually the way of specifying the models with ``fields.Binary`` fields that should be stored on s3 instead of local file storage or db. Don't specify anything if you want to store all your attachment data from ``fields.Binary`` and also ordinary attachments on s3.
   * ``s3.access_key_id``: S3 access key ID
   * ``s3.secret_key``: S3 secret access key
+  * ``s3.minio``: true if the files are saved to Minio instead of S3, false otherwise
+  * ``s3.url``: Minio URL
 
 The settings are also available from the ``Settings >> Technical >> Database Structure >> S3 Settings``.
 

--- a/ir_attachment_s3/views/res_config_settings_views.xml
+++ b/ir_attachment_s3/views/res_config_settings_views.xml
@@ -37,6 +37,18 @@
                   </div>
                 </div>
                 <div class="content-group">
+                  <div class="mt16 row">
+                    <label for="s3_minio" string="Use Minio?" class="col-xs-3 col-md-3 o_light_label"/>
+                    <field name="s3_minio" class="oe_inline"/>
+                  </div>
+                </div>
+                <div class="content-group" attrs="{'invisible':[('s3_minio', '=', False)]}">
+                  <div class="mt16 row">
+                    <label for="s3_url" string="Minio URL" class="col-xs-3 col-md-3 o_light_label"/>
+                    <field name="s3_url" class="oe_inline" attrs="{'required':[('s3_minio', '!=', False)]}"/>
+                  </div>
+                </div>
+                <div class="content-group">
                   <div class="mt16">
                     <button name="upload_existing" type="object" string="Upload existing attachments"/>
                   </div>


### PR DESCRIPTION
This modification allows to use Minio open source storage server as the attachment store instead of Amazon S3.