### PR TITLE
[11.0][FIX]web_debranding_decode_bug

### DIFF
--- a/web_debranding/models/ir_translation.py
+++ b/web_debranding/models/ir_translation.py
@@ -57,7 +57,10 @@ def debrand(env, source, is_code=False):
 
 
 def debrand_bytes(env, source):
-    return bytes(debrand(env, source.decode('utf-8')), 'utf-8')
+    if source:
+        return bytes(debrand(env, source.decode('utf-8')), 'utf-8')
+    else:
+        return bytes('', 'utf-8')
 
 
 class IrTranslation(models.Model):


### PR DESCRIPTION
If source is empty, decode will fail.