### PR TITLE
[IMP] ir_attachment_url: allow to get url

### DIFF
--- a/ir_attachment_url/models/ir_attachment.py
+++ b/ir_attachment_url/models/ir_attachment.py
@@ -10,12 +10,12 @@ class IrAttachment(models.Model):
 
     @api.depends("store_fname", "db_datas")
     def _compute_datas(self):
-        return_url = self._context.get('return_url')
+        attachment_return_url = self._context.get("attachment_return_url")
         bin_size = self._context.get("bin_size")
         url_records = self.filtered(lambda r: r.type == "url" and r.url)
         for attach in url_records:
             if not bin_size:
-                if return_url:
+                if attachment_return_url:
                     attach.datas = attach.url
                     continue
                 r = requests.get(attach.url, timeout=5)

--- a/ir_attachment_url/models/ir_attachment.py
+++ b/ir_attachment_url/models/ir_attachment.py
@@ -10,10 +10,14 @@ class IrAttachment(models.Model):
 
     @api.depends("store_fname", "db_datas")
     def _compute_datas(self):
+        return_url = self._context.get('return_url')
         bin_size = self._context.get("bin_size")
         url_records = self.filtered(lambda r: r.type == "url" and r.url)
         for attach in url_records:
             if not bin_size:
+                if return_url:
+                    attach.datas = attach.url
+                    continue
                 r = requests.get(attach.url, timeout=5)
                 attach.datas = base64.b64encode(r.content)
             else:


### PR DESCRIPTION
First, thanks for this great module!

With this change it is easy to, for example, export images (urls) and load them on a new database, for eg.
`data = source_db.env['product.template'].export_data(['id', 'image'])`
and then
`target_db.env['product.template'].with_context(attachment_return_url=True).load(['id', 'image'], data['datas'])`

