### PR TITLE
[11.0] web_website: fix _get_website_id wrongly returning SUPERUSER_ID's website

### DIFF
--- a/web_website/README.rst
+++ b/web_website/README.rst
@@ -38,6 +38,7 @@ Roadmap
 * TODO: Use context on switching between websites to allow work with different
   websites at the same time by using different browser tabs. It also fixes
   problem of using superuser's configuration when ``sudo()`` is used.
+  This is partly fixed by checking context's uid in ``_get_website_id`` method.
 
 Credits
 =======
@@ -55,7 +56,7 @@ Maintainers
 * `IT-Projects LLC <https://it-projects.info>`__
 
       To get a guaranteed support
-      you are kindly requested to purchase the module 
+      you are kindly requested to purchase the module
       at `odoo apps store <https://apps.odoo.com/apps/modules/11.0/web_website/>`__.
 
       Thank you for understanding!

--- a/web_website/__manifest__.py
+++ b/web_website/__manifest__.py
@@ -6,7 +6,7 @@
     "category": "Hidden",
     # "live_test_url": "",
     "images": [],
-    "version": "11.0.3.0.4",
+    "version": "11.0.3.0.5",
     "application": False,
     "author": "IT-Projects LLC, Ivan Yelizariev",
     "support": "apps@itpp.dev",

--- a/web_website/doc/changelog.rst
+++ b/web_website/doc/changelog.rst
@@ -1,3 +1,7 @@
+`3.0.5`
+-------
+- **Fix:** _get_website_id could return SUPERUSER_ID's website instead of current user
+
 `3.0.4`
 -------
 - **Fix:** Incorrect return data in get_multi in case of 'many2one' field, id instead of a record

--- a/web_website/models/ir_property.py
+++ b/web_website/models/ir_property.py
@@ -47,10 +47,15 @@ class IrProperty(models.Model):
 
     @api.model
     def _get_website_id(self):
-        website_id = (
-            self._context.get("website_id") or self.env.user.backend_website_id.id
-        )
-        return website_id
+        if self._context.get("website_id"):
+            return self._context.get("website_id")
+
+        if self._context.get("uid"):
+            user = self.env["res.users"].browse(self._context["uid"])
+        else:
+            user = self.env.user
+
+        return user.backend_website_id.id
 
     def _get_domain(self, prop_name, model):
         domain = super(IrProperty, self)._get_domain(prop_name, model)


### PR DESCRIPTION
Предыстория.
Есть модуль mail_multi_website, в котором можно задать шаблон (mail.template) в зависимость от выбранного вебсайта.

В одной вкладке заходим от админа на какой-нибудь шаблон. В другой вкладке (с режимом инкогнито например) заходим от демо на тот-же шаблон.

Для разных вебсайтов через админа редактируем тела шаблонов для того, чтобы понимать, какой шаблон какому-вебсайту соотвествует.

Далее следите за руками. Админ меняет вебсайт. У демо ничего не меняем, перезагружаем страницу с шаблоном и ТЕКСТ ШАБЛОНА СМЕНИЛСЯ. Админ снова меняет вебсайт, у демо перезагружаем страницу и ТЕКСТ ШАБЛОНА СНОВА СМЕНИЛСЯ.

Почему так? Смотрим сюда:
https://github.com/odoo/odoo/blob/e4bef56cbbda3eba3d6171132948b74e0dd3ae90/odoo/fields.py#L633-L634

В этом месте self.env.user - это может быть демо, а вот внутри Propery.get_multi self.env.user - это уже SUPERUSER_ID