### PR TITLE
odoo_backup_sh: added ability to derive method, that stores backup

### DIFF
--- a/odoo_backup_sh/README.rst
+++ b/odoo_backup_sh/README.rst
@@ -229,4 +229,4 @@ Usage instructions: `<doc/index.rst>`_
 
 Changelog: `<doc/changelog.rst>`_
 
-Tested on Odoo 12.0 483b6024cd44fcc6e2b987505beb739014b51856
+Tested on Odoo 13.0 a8125ebc1480b5b215bf3737f4e799ead5b34d9d

--- a/odoo_backup_sh/__manifest__.py
+++ b/odoo_backup_sh/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Backup",
     # "live_test_url": "",
     "images": ["images/odoo-backup.sh.jpg"],
-    "version": "13.0.1.0.2",
+    "version": "13.0.1.0.3",
     "author": "IT-Projects LLC",
     "support": "apps@itpp.dev",
     "website": "https://apps.odoo.com/apps/modules/13.0/odoo_backup_sh/",

--- a/odoo_backup_sh/doc/changelog.rst
+++ b/odoo_backup_sh/doc/changelog.rst
@@ -1,3 +1,8 @@
+`1.0.3`
+-------
+
+- **Improvement:** Added ability to derive method, that stores backup
+
 `1.0.2`
 -------
 


### PR DESCRIPTION
Возникла задача хранить бэкапы еще и локально. Для требуется dump_stream для получения доступа к содержимому бэкапа и info_file_content чтобы туда вставлять отметку о том, что был создан бэкап еще и локально.

Например вот так: https://github.com/em230418/saas-addons/commit/895c1a5d08aca0adc9c7739ec6c63d6cae436dc2#diff-7fa3e6709045fc6052ffd0be8866e15cR12-R30