### PR TITLE
12.0 ir_attachment_url attrs maxrecursion

### DIFF
--- a/ir_attachment_url/models/binary_fields.py
+++ b/ir_attachment_url/models/binary_fields.py
@@ -34,6 +34,7 @@ def get_mimetype_and_optional_content_by_url(url):
 binary_original_create = fields.Binary.create
 binary_original_write = fields.Binary.write
 
+
 # based on https://github.com/odoo/odoo/blob/bba7a6b2c46320af150f34359f742ee4e0116e66/odoo/fields.py#L1853-L1872
 def create(self, record_values):
     assert self.attachment

--- a/ir_attachment_url/models/binary_fields.py
+++ b/ir_attachment_url/models/binary_fields.py
@@ -31,100 +31,102 @@ def get_mimetype_and_optional_content_by_url(url):
     return mimetype, content
 
 
-class Binary(fields.Binary):
+binary_original_create = fields.Binary.create
+binary_original_write = fields.Binary.write
 
-    # based on https://github.com/odoo/odoo/blob/bba7a6b2c46320af150f34359f742ee4e0116e66/odoo/fields.py#L1853-L1872
-    def create(self, record_values):
-        assert self.attachment
-        if not record_values:
-            return
-        # create the attachments that store the values
-        env = record_values[0][0].env
+# based on https://github.com/odoo/odoo/blob/bba7a6b2c46320af150f34359f742ee4e0116e66/odoo/fields.py#L1853-L1872
+def create(self, record_values):
+    assert self.attachment
+    if not record_values:
+        return
+    # create the attachments that store the values
+    env = record_values[0][0].env
 
-        # redefined part starts here
-        url_record_values = []
-        other_record_values = []
-        for pair in record_values:
-            value = pair[1]
-            if image.is_url(value):
-                url_record_values.append(pair)
-            else:
-                other_record_values.append(pair)
+    # redefined part starts here
+    url_record_values = []
+    other_record_values = []
+    for pair in record_values:
+        value = pair[1]
+        if image.is_url(value):
+            url_record_values.append(pair)
+        else:
+            other_record_values.append(pair)
 
-        with env.norecompute():
-            env["ir.attachment"].sudo().with_context(
-                binary_field_real_user=env.user
-            ).create(
-                [
+    with env.norecompute():
+        env["ir.attachment"].sudo().with_context(
+            binary_field_real_user=env.user
+        ).create(
+            [
+                {
+                    "name": self.name,
+                    "res_model": self.model_name,
+                    "res_field": self.name,
+                    "res_id": record.id,
+                    "type": "url",  # it is not binary like in original method
+                    "url": value,  # also using url field instead of datas
+                }
+                for record, value in url_record_values
+                if value
+            ]
+        )
+    # calling original create method for non URLs
+    binary_original_create(self, other_record_values)
+
+
+def write(self, records, value):
+    domain = [
+        ("res_model", "=", self.model_name),
+        ("res_field", "=", self.name),
+        ("res_id", "in", records.ids),
+    ]
+    atts = records.env["ir.attachment"].sudo().search(domain)
+    if value and atts.url and atts.type == "url" and not image.is_url(value):
+        atts.write({"url": None, "type": "binary"})
+    if value and image.is_url(value):
+        # save_option = records.env['ir.config_parameter'].get_param('ir_attachment_url.storage', default='url')
+        with records.env.norecompute():
+            # commented out some strange stuff
+            # https://github.com/it-projects-llc/misc-addons/pull/775/files#r302856876
+            # if value and save_option != 'url':
+            #     r = requests.get(value, timeout=5)
+            #     base64source = base64.b64encode(r.content)
+            #     super(Binary, self).write(records, base64source)
+            if value:
+                mimetype, content = get_mimetype_and_optional_content_by_url(value)
+                index_content = records.env["ir.attachment"]._index(
+                    content, None, mimetype
+                )
+
+                # update the existing attachments
+                atts.write(
                     {
-                        "name": self.name,
-                        "res_model": self.model_name,
-                        "res_field": self.name,
-                        "res_id": record.id,
-                        "type": "url",  # it is not binary like in original method
-                        "url": value,  # also using url field instead of datas
+                        "url": value,
+                        "mimetype": mimetype,
+                        "datas": None,
+                        "type": "url",
+                        "index_content": index_content,
                     }
-                    for record, value in url_record_values
-                    if value
-                ]
-            )
-        # calling original create method for non URLs
-        super(Binary, self).create(other_record_values)
-        # redefined part ends here
+                )
 
-    def write(self, records, value):
-        domain = [
-            ("res_model", "=", self.model_name),
-            ("res_field", "=", self.name),
-            ("res_id", "in", records.ids),
-        ]
-        atts = records.env["ir.attachment"].sudo().search(domain)
-        if value and atts.url and atts.type == "url" and not image.is_url(value):
-            atts.write({"url": None, "type": "binary"})
-        if value and image.is_url(value):
-            # save_option = records.env['ir.config_parameter'].get_param('ir_attachment_url.storage', default='url')
-            with records.env.norecompute():
-                # commented out some strange stuff
-                # https://github.com/it-projects-llc/misc-addons/pull/775/files#r302856876
-                # if value and save_option != 'url':
-                #     r = requests.get(value, timeout=5)
-                #     base64source = base64.b64encode(r.content)
-                #     super(Binary, self).write(records, base64source)
-                if value:
-                    mimetype, content = get_mimetype_and_optional_content_by_url(value)
-                    index_content = records.env["ir.attachment"]._index(
-                        content, None, mimetype
-                    )
-
-                    # update the existing attachments
-                    atts.write(
+                # create the missing attachments
+                for record in records - records.browse(atts.mapped("res_id")):
+                    atts.create(
                         {
+                            "name": self.name,
+                            "res_model": record._name,
+                            "res_field": self.name,
+                            "res_id": record.id,
+                            "type": "url",
                             "url": value,
                             "mimetype": mimetype,
-                            "datas": None,
-                            "type": "url",
                             "index_content": index_content,
                         }
                     )
-
-                    # create the missing attachments
-                    for record in records - records.browse(atts.mapped("res_id")):
-                        atts.create(
-                            {
-                                "name": self.name,
-                                "res_model": record._name,
-                                "res_field": self.name,
-                                "res_id": record.id,
-                                "type": "url",
-                                "url": value,
-                                "mimetype": mimetype,
-                                "index_content": index_content,
-                            }
-                        )
-                else:
-                    atts.unlink()
-        else:
-            super(Binary, self).write(records, value)
+            else:
+                atts.unlink()
+    else:
+        binary_original_write.write(self, records, value)
 
 
-fields.Binary = Binary
+fields.Binary.create = create
+fields.Binary.write = write

--- a/ir_attachment_url/models/binary_fields.py
+++ b/ir_attachment_url/models/binary_fields.py
@@ -125,7 +125,7 @@ def write(self, records, value):
             else:
                 atts.unlink()
     else:
-        binary_original_write.write(self, records, value)
+        binary_original_write(self, records, value)
 
 
 fields.Binary.create = create


### PR DESCRIPTION
Since Odoo commit https://github.com/odoo/odoo/commit/4ad80e52d390f8b8984f006ecd666a50991ddf08 ir_attachment_url is throwing a maxrecursion error.

I think this is the safest way to fix it longer term, since only the create and write methods need monkey patching?

One of my clients has this module purchased from the app store, but they're struggling to find their credentials to raise a support ticket. I apologise if this is not the appropriate way to raise an issue with this module.