### PR TITLE
FIX(web_debranding): bot.js made further inheritance impossible

### DIFF
--- a/web_debranding/static/src/js/bot.js
+++ b/web_debranding/static/src/js/bot.js
@@ -8,9 +8,9 @@ odoo.define("web_debranding.bot", function(require) {
     var session = require("web.session");
     var ODOOBOT_ID = "ODOOBOT";
 
-    var make_message_super = chat_manager.make_message;
+    chat_manager._make_message_debranding_bot_super = chat_manager.make_message;
     chat_manager.make_message = function(data) {
-        var msg = make_message_super(data);
+        var msg = this._make_message_debranding_bot_super(data);
         if (msg.author_id === ODOOBOT_ID) {
             msg.avatar_src =
                 "/web/binary/company_logo?company_id=" + session.company_id;


### PR DESCRIPTION
Further Inheritance from other Modules like https://github.com/OCA/social/blob/11.0/mail_tracking/static/src/js/failed_message.js#L210 will fail because `this` will be undefined in the original implementation