### PR TITLE
[12.0][FIX] project_task_subtask: Invalid stylesheet type

### DIFF
--- a/project_task_subtask/views/assets.xml
+++ b/project_task_subtask/views/assets.xml
@@ -10,7 +10,7 @@
         <xpath expr="." position="inside">
             <link
                 rel="stylesheet"
-                type="text/less"
+                type="text/css"
                 href="/project_task_subtask/static/src/css/kanban_styles.css"
             />
             <script


### PR DESCRIPTION
Asset bundle cannot compile when lessc is not installed.
But this stylesheet is pure css so set it accordingly.