### PR TITLE
allows to configure generic object storage other than amazon s3 (eg: wasabi.com)

### DIFF
--- a/ir_attachment_s3/views/res_config_settings_views.xml
+++ b/ir_attachment_s3/views/res_config_settings_views.xml
@@ -72,6 +72,19 @@
                                 <div class="content-group">
                                     <div class="mt16 row">
                                         <label
+                                            for="s3_region"
+                                            string="S3 Region"
+                                            class="col-xs-3 col-md-3 o_light_label"
+                                        />
+                                        <field
+                                            name="s3_region"
+                                            class="oe_inline"
+                                        />
+                                    </div>
+                                </div>
+                                <div class="content-group">
+                                    <div class="mt16 row">
+                                        <label
                                             for="s3_obj_url"
                                             string="S3 URL"
                                             class="col-xs-3 col-md-3 o_light_label"


### PR DESCRIPTION
![Selection_014](https://user-images.githubusercontent.com/57627622/123513818-8bf03080-d6b9-11eb-9232-f2957a101725.png)

I have made a piece of feature that allows to use at other object storage (another alternate of amazon s3), in my case study I use https://wasabi.com.

This pull request migh be usefull for next release.

Thanks.

