### PR TITLE
improve function _file_read

### DIFF
--- a/ir_attachment_s3/models/ir_attachment.py
+++ b/ir_attachment_s3/models/ir_attachment.py
@@ -71,8 +71,7 @@ class IrAttachment(models.Model):
 
         obj = bucket.Object(file_id)
         data = obj.get()
-
-        return base64.b64encode(b"".join(data["Body"]))
+        return data['Body'].read()
 
     def _file_delete(self, fname):
         if not fname.startswith(PREFIX):


### PR DESCRIPTION
Found another bugs while tried to load binary file through `widget="image"` mode, for example:

`<field name="image" widget="image" class="ml-4 oe_avatar" required="1"/>`.

Before:
![Selection_015](https://user-images.githubusercontent.com/57627622/123514144-8f84b700-d6bb-11eb-9f0b-7eeeea315526.png)

After:
![Selection_016](https://user-images.githubusercontent.com/57627622/123514148-97dcf200-d6bb-11eb-96ed-f85dac4f382e.png)


