### PR TITLE
FIX: convert property field type date correctly

### DIFF
--- a/web_website/models/ir_property.py
+++ b/web_website/models/ir_property.py
@@ -233,6 +233,10 @@ class IrProperty(models.Model):
 
             def clean(data):
                 return data and self.env[field.comodel_name].browse(data[1])
+        elif field.type == "date":
+
+            def clean(data):
+                return data[1].date() if data and data[1] else False
 
         else:
 


### PR DESCRIPTION
Odoo store field as datetime(https://github.com/odoo/odoo/blob/12.0/odoo/addons/base/models/ir_property.py#L16), but on read take only date(https://github.com/odoo/odoo/blob/12.0/odoo/addons/base/models/ir_property.py#L29)
https://github.com/odoo/odoo/blob/12.0/odoo/addons/base/models/ir_property.py#L257

![image](https://user-images.githubusercontent.com/7775116/130675724-5578334f-6105-4781-830f-78ee977fdacb.png)

Before commit raise error TypeError: 2021-08-31 05:00:00 (field res.partner.payment_next_action_date) must be string or date, not datetime. 
![image](https://user-images.githubusercontent.com/7775116/130675640-ae6478b9-fe3c-48bb-9ad9-6eddae42e0af.png)

when use enterprise and set a payment_next_action_date from following report https://github.com/odoo/enterprise/blob/12.0/account_reports/models/res_partner.py#L14